### PR TITLE
feat: add NPC behavior trees

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "uuid": "^11.0.3"
   },
   "devDependencies": {
-    "@assetpack/core": "^1.2.2",
+    "@assetpack/core": "^1.2.3",
     "@trezy-studios/eslint-config": "^1.0.0",
     "@trezy-studios/eslint-config-react": "^1.0.0",
     "@types/eslint-plugin-jsx-a11y": "^6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@pixi/devtools": "^2.0.1",
     "@pixi/react": "8.0.0-beta.14",
+    "behaviortree": "^3.0.0-beta.1",
     "matter-js": "^0.20.0",
     "miniplex": "^2.0.0",
     "miniplex-react": "^2.0.1",

--- a/src/behaviors/ChooseLocationTask.ts
+++ b/src/behaviors/ChooseLocationTask.ts
@@ -1,0 +1,70 @@
+// Module imports
+import {
+	SUCCESS,
+	Task,
+} from 'behaviortree'
+
+
+
+
+
+// Local imports
+import { ActorType } from '@/typedefs/ActorType'
+import { Vector2 } from '@/typedefs/Vector2'
+
+
+
+
+
+// Types
+type ChooseLocationBlackboard = {
+	destination?: Vector2,
+	entity: ActorType,
+	home: Vector2,
+	wanderRadius: number,
+}
+
+
+
+
+
+export const ChooseLocationTask = new Task({
+	// (optional) this function is called directly before the run method
+	// is called. It allows you to setup things before starting to run
+	// start: function (blackboard) {
+	// 	blackboard.isStarted = true
+	// },
+
+	// (optional) this function is called directly after the run method
+	// is completed with either this.success() or this.fail(). It allows you to clean up
+	// things, after you run the task.
+	// end: function (blackboard) {
+	// 	blackboard.isStarted = false
+	// },
+
+	/**
+	 * The core of the task.
+	 *
+	 * @param blackboard The behavior tree's data store.
+	 * @returns The status of the task.
+	 */
+	run: (blackboard: ChooseLocationBlackboard) => {
+		const {
+			entity,
+			home,
+			wanderRadius,
+		} = blackboard
+
+		const xDirection = Math.random() > 0.5 ? 1 : -1
+		const yDirection = Math.random() > 0.5 ? 1 : -1
+
+		entity.destination!.set(() => ({
+			value: {
+				x: ((Math.random() * wanderRadius) * xDirection) + home.x,
+				y: ((Math.random() * wanderRadius) * yDirection) + home.y,
+			},
+		}))
+
+		return SUCCESS
+	},
+})

--- a/src/behaviors/ChooseLocationTask.ts
+++ b/src/behaviors/ChooseLocationTask.ts
@@ -47,8 +47,8 @@ export const ChooseLocationTask = new Task({
 
 		entity.destination!.set(() => ({
 			value: {
-				x: ((Math.random() * wanderRadius) * xDirection) + home.x,
-				y: ((Math.random() * wanderRadius) * yDirection) + home.y,
+				x: Math.round(((Math.random() * wanderRadius) * xDirection) + home.x),
+				y: Math.round(((Math.random() * wanderRadius) * yDirection) + home.y),
 			},
 		}))
 

--- a/src/behaviors/ChooseLocationTask.ts
+++ b/src/behaviors/ChooseLocationTask.ts
@@ -29,26 +29,13 @@ type ChooseLocationBlackboard = {
 
 
 export const ChooseLocationTask = new Task({
-	// (optional) this function is called directly before the run method
-	// is called. It allows you to setup things before starting to run
-	// start: function (blackboard) {
-	// 	blackboard.isStarted = true
-	// },
-
-	// (optional) this function is called directly after the run method
-	// is completed with either this.success() or this.fail(). It allows you to clean up
-	// things, after you run the task.
-	// end: function (blackboard) {
-	// 	blackboard.isStarted = false
-	// },
-
 	/**
-	 * The core of the task.
+	 * Chooses a random location within the wander radius of the entity.
 	 *
 	 * @param blackboard The behavior tree's data store.
 	 * @returns The status of the task.
 	 */
-	run: (blackboard: ChooseLocationBlackboard) => {
+	run(blackboard: ChooseLocationBlackboard) {
 		const {
 			entity,
 			home,

--- a/src/behaviors/IdleTask.ts
+++ b/src/behaviors/IdleTask.ts
@@ -64,7 +64,7 @@ export const IdleTask = new Task({
 			min: minIdle,
 		} = blackboard.entity.idle!
 
-		blackboard.idleDuration = minIdle + ((maxIdle - minIdle) * Math.random())
+		blackboard.idleDuration = Math.round(minIdle + ((maxIdle - minIdle) * Math.random()))
 		blackboard.idleStartedAt = store.state.now
 	},
 })

--- a/src/behaviors/IdleTask.ts
+++ b/src/behaviors/IdleTask.ts
@@ -1,0 +1,70 @@
+// Module imports
+import {
+	RUNNING,
+	SUCCESS,
+	Task,
+} from 'behaviortree'
+
+
+
+
+
+// Local imports
+import { type NPCType } from '@/typedefs/NPCType'
+import { store } from '@/store/store'
+
+
+
+
+
+// Types
+interface IdleBlackboard {
+	entity: NPCType,
+	idleDuration?: number,
+	idleStartedAt?: number,
+}
+
+
+
+
+
+export const IdleTask = new Task({
+	/**
+	 * Delete unnecessary data from the blackboard when idling is complete.
+	 *
+	 * @param blackboard The behavior tree's data store.
+	 */
+	end(blackboard: IdleBlackboard) {
+		delete blackboard.idleDuration
+		delete blackboard.idleStartedAt
+	},
+
+	/**
+	 * End the idle if the duration has completed.
+	 *
+	 * @param blackboard The behavior tree's data store.
+	 * @returns The status of the task.
+	 */
+	run(blackboard: IdleBlackboard) {
+		if (store.state.now >= (blackboard.idleStartedAt! + blackboard.idleDuration!)) {
+			return SUCCESS
+		}
+
+		return RUNNING
+	},
+
+	/**
+	 * Generates a random idle duration and sets required values for the idle.
+	 *
+	 * @param blackboard The behavior tree's data store.
+	 */
+	start(blackboard: IdleBlackboard) {
+		const {
+			max: maxIdle,
+			min: minIdle,
+		} = blackboard.entity.idle!
+
+		blackboard.idleDuration = minIdle + ((maxIdle - minIdle) * Math.random())
+		blackboard.idleStartedAt = store.state.now
+	},
+})

--- a/src/behaviors/MoveToTask.ts
+++ b/src/behaviors/MoveToTask.ts
@@ -11,6 +11,7 @@ import {
 
 
 // Local imports
+import { isEntityNearDestination } from '@/helpers/isEntityNearDestination'
 import { type NPCType } from '@/typedefs/NPCType'
 
 
@@ -55,6 +56,10 @@ export const MoveToTask = new Task({
 			return FAILURE
 		}
 
+		if (isEntityNearDestination(entity)) {
+			return SUCCESS
+		}
+
 		const {
 			x: entityX,
 			y: entityY,
@@ -68,15 +73,6 @@ export const MoveToTask = new Task({
 		const dy = destinationY - entityY
 
 		const magnitude = Math.sqrt((dx ** 2) + (dy ** 2))
-
-		if (magnitude === 0) {
-			entity.destination.set(() => ({ value: null }))
-			entity.velocity.set(() => ({
-				x: 0,
-				y: 0,
-			}))
-			return SUCCESS
-		}
 
 		entity.velocity.set(() => ({
 			x: (dx / magnitude) * entity.speed,

--- a/src/behaviors/MoveToTask.ts
+++ b/src/behaviors/MoveToTask.ts
@@ -1,0 +1,88 @@
+// Module imports
+import {
+	FAILURE,
+	RUNNING,
+	SUCCESS,
+	Task,
+} from 'behaviortree'
+
+
+
+
+
+// Local imports
+import { type NPCType } from '@/typedefs/NPCType'
+
+
+
+
+
+// Types
+type MoveToBlackboard = {
+	entity: NPCType,
+}
+
+
+
+
+
+export const MoveToTask = new Task({
+	/**
+	 * The core of the task.
+	 *
+	 * @param blackboard The behavior tree's data store.
+	 */
+	end: (blackboard: MoveToBlackboard) => {
+		const { entity } = blackboard
+
+		entity.destination.set(() => ({ value: null }))
+		entity.velocity.set(() => ({
+			x: 0,
+			y: 0,
+		}))
+	},
+
+	/**
+	 * The core of the task.
+	 *
+	 * @param blackboard The behavior tree's data store.
+	 * @returns The status of the task.
+	 */
+	run: (blackboard: MoveToBlackboard) => {
+		const { entity } = blackboard
+
+		if (!entity.destination.state.value) {
+			return FAILURE
+		}
+
+		const {
+			x: entityX,
+			y: entityY,
+		} = entity.position.state
+		const {
+			x: destinationX,
+			y: destinationY,
+		} = entity.destination.state.value
+
+		const dx = destinationX - entityX
+		const dy = destinationY - entityY
+
+		const magnitude = Math.sqrt((dx ** 2) + (dy ** 2))
+
+		if (magnitude === 0) {
+			entity.destination.set(() => ({ value: null }))
+			entity.velocity.set(() => ({
+				x: 0,
+				y: 0,
+			}))
+			return SUCCESS
+		}
+
+		entity.velocity.set(() => ({
+			x: (dx / magnitude) * entity.speed,
+			y: (dy / magnitude) * entity.speed,
+		}))
+
+		return RUNNING
+	},
+})

--- a/src/behaviors/MoveToTask.ts
+++ b/src/behaviors/MoveToTask.ts
@@ -29,11 +29,11 @@ type MoveToBlackboard = {
 
 export const MoveToTask = new Task({
 	/**
-	 * The core of the task.
+	 * Stops the entity's movement when the movement is complete.
 	 *
 	 * @param blackboard The behavior tree's data store.
 	 */
-	end: (blackboard: MoveToBlackboard) => {
+	end(blackboard: MoveToBlackboard) {
 		const { entity } = blackboard
 
 		entity.destination.set(() => ({ value: null }))
@@ -44,12 +44,12 @@ export const MoveToTask = new Task({
 	},
 
 	/**
-	 * The core of the task.
+	 * Keeps the entity moving towards its destination.
 	 *
 	 * @param blackboard The behavior tree's data store.
 	 * @returns The status of the task.
 	 */
-	run: (blackboard: MoveToBlackboard) => {
+	run(blackboard: MoveToBlackboard) {
 		const { entity } = blackboard
 
 		if (!entity.destination.state.value) {

--- a/src/behaviors/WanderSequence.ts
+++ b/src/behaviors/WanderSequence.ts
@@ -7,6 +7,7 @@ import { Sequence } from 'behaviortree'
 
 // Local imports
 import { ChooseLocationTask } from '@/behaviors/ChooseLocationTask'
+import { IdleTask } from '@/behaviors/IdleTask'
 import { MoveToTask } from '@/behaviors/MoveToTask'
 
 
@@ -15,6 +16,7 @@ import { MoveToTask } from '@/behaviors/MoveToTask'
 
 export const WanderSequence = new Sequence({
 	nodes: [
+		IdleTask,
 		ChooseLocationTask,
 		MoveToTask,
 	],

--- a/src/behaviors/WanderSequence.ts
+++ b/src/behaviors/WanderSequence.ts
@@ -1,0 +1,21 @@
+// Module imports
+import { Sequence } from 'behaviortree'
+
+
+
+
+
+// Local imports
+import { ChooseLocationTask } from '@/behaviors/ChooseLocationTask'
+import { MoveToTask } from '@/behaviors/MoveToTask'
+
+
+
+
+
+export const WanderSequence = new Sequence({
+	nodes: [
+		ChooseLocationTask,
+		MoveToTask,
+	],
+})

--- a/src/constants/ENTITY_CATALOGUE.ts
+++ b/src/constants/ENTITY_CATALOGUE.ts
@@ -1,6 +1,7 @@
 // Local imports
 import { COLLISION_CATEGORIES } from '@/constants/COLLISION_CATEGORIES'
 import { type EntityDefinition } from '@/typedefs/EntityDefinition'
+import { WanderSequence } from '@/behaviors/WanderSequence'
 
 
 
@@ -37,6 +38,7 @@ export const ENTITY_CATALOGUE: Record<string, EntityDefinition> = {
 
 	'merchant': {
 		actorType: 'merchant',
+		behaviorTree: WanderSequence,
 		boundingBox: {
 			height: 25,
 			width: 38,
@@ -59,6 +61,6 @@ export const ENTITY_CATALOGUE: Record<string, EntityDefinition> = {
 		}],
 		health: 100,
 		speed: 1,
-		zOffset: 7
+		zOffset: 7,
 	},
 }

--- a/src/constants/ENTITY_CATALOGUE.ts
+++ b/src/constants/ENTITY_CATALOGUE.ts
@@ -60,7 +60,11 @@ export const ENTITY_CATALOGUE: Record<string, EntityDefinition> = {
 			y: 22,
 		}],
 		health: 100,
-		speed: 1,
+		idle: {
+			max: 10 * 1000,
+			min: 2 * 1000,
+		},
+		speed: 0.5,
 		zOffset: 7,
 	},
 }

--- a/src/helpers/ECS.ts
+++ b/src/helpers/ECS.ts
@@ -16,6 +16,7 @@ export const ECS = createReactAPI(store.state.world)
 
 export const query = {
 	actor: ECS.world.with('actorType', 'attack', 'bodies', 'position', 'velocity', 'zIndex'),
+	npc: ECS.world.with('actorType', 'attack', 'behaviorTree', 'bodies', 'destination', 'position', 'velocity', 'zIndex'),
 	sortable: ECS.world.with('position', 'zIndex', 'zOffset'),
 	spawn: ECS.world.with('position', 'spawn'),
 	tile: ECS.world.with('position', 'tile', 'zIndex'),

--- a/src/helpers/createActorEntity.ts
+++ b/src/helpers/createActorEntity.ts
@@ -3,7 +3,7 @@ import {
 	Bodies,
 	Composite,
 } from 'matter-js'
-import { makeStore } from 'statery'
+import { BehaviorTree } from 'behaviortree'
 
 
 
@@ -11,6 +11,7 @@ import { makeStore } from 'statery'
 
 // Local imports
 import { createAttackState } from '@/helpers/createAttackState'
+import { createDestinationState } from '@/helpers/createDestinationState'
 import { createHealthState } from '@/helpers/createHealthState'
 import { createPositionState } from '@/helpers/createPositionState'
 import { createVelocityState } from '@/helpers/createVelocityState'
@@ -43,7 +44,7 @@ export function createActorEntity(
 		actorType: entityDefinition.actorType,
 		attack: createAttackState(),
 		bodies: Composite.create(),
-		health: makeStore({ value: entityDefinition.health }),
+		destination: createDestinationState(),
 		health: createHealthState(entityDefinition.health),
 		speed: entityDefinition.speed,
 		position: createPositionState(startingX, startingY),
@@ -51,6 +52,20 @@ export function createActorEntity(
 		zIndex: createZIndexState(0),
 		zOffset: entityDefinition.zOffset,
 	})
+
+	if (entityDefinition.behaviorTree) {
+		entity.behaviorTree = new BehaviorTree({
+			tree: entityDefinition.behaviorTree,
+			blackboard: {
+				entity,
+				home: {
+					x: startingX,
+					y: startingY,
+				},
+				wanderRadius: 10,
+			},
+		})
+	}
 
 	entityDefinition.colliders.forEach(colliderDefinition => {
 		const colliderOptions = {

--- a/src/helpers/createActorEntity.ts
+++ b/src/helpers/createActorEntity.ts
@@ -67,6 +67,10 @@ export function createActorEntity(
 		})
 	}
 
+	if (entityDefinition.idle) {
+		entity.idle = entityDefinition.idle
+	}
+
 	entityDefinition.colliders.forEach(colliderDefinition => {
 		const colliderOptions = {
 			...DEFAULT_BODY_OPTIONS,

--- a/src/helpers/createActorEntity.ts
+++ b/src/helpers/createActorEntity.ts
@@ -11,6 +11,10 @@ import { makeStore } from 'statery'
 
 // Local imports
 import { createAttackState } from '@/helpers/createAttackState'
+import { createHealthState } from '@/helpers/createHealthState'
+import { createPositionState } from '@/helpers/createPositionState'
+import { createVelocityState } from '@/helpers/createVelocityState'
+import { createZIndexState } from '@/helpers/createZIndexState'
 import { DEFAULT_BODY_OPTIONS } from '@/constants/DEFAULT_BODY_OPTIONS'
 import { ECS } from '@/helpers/ECS'
 import { type EntityDefinition } from '@/typedefs/EntityDefinition'
@@ -26,33 +30,25 @@ import { store } from '@/store/store'
  * @param entityDefinition The definition of the entity from the entity catalogue.
  * @param startingX The X position at which this entity will start.
  * @param startingY The Y position at which this entity will start.
- * @param entityProps Additional props to be set on the body.
  * @returns The new entity.
  */
 export function createActorEntity(
 	entityDefinition: EntityDefinition,
 	startingX: number,
 	startingY: number,
-	entityProps = {},
 ) {
 	const { physicsEngine } = store.state
 
 	const entity = ECS.world.add({
-		...entityProps,
 		actorType: entityDefinition.actorType,
 		attack: createAttackState(),
 		bodies: Composite.create(),
 		health: makeStore({ value: entityDefinition.health }),
+		health: createHealthState(entityDefinition.health),
 		speed: entityDefinition.speed,
-		position: makeStore({
-			x: startingX,
-			y: startingY,
-		}),
-		velocity: makeStore({
-			x: 0,
-			y: 0,
-		}),
-		zIndex: makeStore({ value: 0 }),
+		position: createPositionState(startingX, startingY),
+		velocity: createVelocityState(0, 0),
+		zIndex: createZIndexState(0),
 		zOffset: entityDefinition.zOffset,
 	})
 

--- a/src/helpers/createDestinationState.ts
+++ b/src/helpers/createDestinationState.ts
@@ -1,0 +1,23 @@
+// Module imports
+import { makeStore } from 'statery'
+
+
+
+
+
+// Local imports
+import { type DestinationState } from '@/typedefs/DestinationState'
+
+
+
+
+
+/**
+ * Creates a new destination state.
+ *
+ * @param initialValue The initial destination.
+ * @returns The destination state.
+ */
+export function createDestinationState(initialValue: DestinationState['value'] = null) {
+	return makeStore<DestinationState>({ value: initialValue })
+}

--- a/src/helpers/createHealthState.ts
+++ b/src/helpers/createHealthState.ts
@@ -1,0 +1,23 @@
+// Module imports
+import { makeStore } from 'statery'
+
+
+
+
+
+// Local imports
+import { type HealthState } from '@/typedefs/HealthState'
+
+
+
+
+
+/**
+ * Creates a new health state.
+ *
+ * @param initialValue The initial health.
+ * @returns The health state.
+ */
+export function createHealthState(initialValue: HealthState['value']) {
+	return makeStore<HealthState>({ value: initialValue })
+}

--- a/src/helpers/createPositionState.ts
+++ b/src/helpers/createPositionState.ts
@@ -1,0 +1,30 @@
+// Module imports
+import { makeStore } from 'statery'
+
+
+
+
+
+// Local imports
+import { type PositionState } from '@/typedefs/PositionState'
+
+
+
+
+
+/**
+ * Creates a new position state.
+ *
+ * @param initialX The initial x position.
+ * @param initialY The initial y position.
+ * @returns The position state.
+ */
+export function createPositionState(
+	initialX: PositionState['x'],
+	initialY: PositionState['y'],
+) {
+	return makeStore<PositionState>({
+		x: initialX,
+		y: initialY,
+	})
+}

--- a/src/helpers/createVelocityState.ts
+++ b/src/helpers/createVelocityState.ts
@@ -1,0 +1,30 @@
+// Module imports
+import { makeStore } from 'statery'
+
+
+
+
+
+// Local imports
+import { type VelocityState } from '@/typedefs/VelocityState'
+
+
+
+
+
+/**
+ * Creates a new velocity state.
+ *
+ * @param initialX The initial x velocity.
+ * @param initialY The initial y velocity.
+ * @returns The velocity state.
+ */
+export function createVelocityState(
+	initialX: VelocityState['x'],
+	initialY: VelocityState['y'],
+) {
+	return makeStore<VelocityState>({
+		x: initialX,
+		y: initialY,
+	})
+}

--- a/src/helpers/createZIndexState.ts
+++ b/src/helpers/createZIndexState.ts
@@ -1,0 +1,23 @@
+// Module imports
+import { makeStore } from 'statery'
+
+
+
+
+
+// Local imports
+import { type ZIndexState } from '@/typedefs/ZIndexState'
+
+
+
+
+
+/**
+ * Creates a new z index state.
+ *
+ * @param initialValue The initial z index.
+ * @returns The z index state.
+ */
+export function createZIndexState(initialValue: ZIndexState['value']) {
+	return makeStore<ZIndexState>({ value: initialValue })
+}

--- a/src/helpers/isEntityNearDestination.ts
+++ b/src/helpers/isEntityNearDestination.ts
@@ -1,0 +1,35 @@
+// Local imports
+import { type NPCType } from '@/typedefs/NPCType'
+
+
+
+
+
+/**
+ * Checks if an entity is within a threshold of its destination.
+ *
+ * @param entity The entity to test.
+ * @param threshold The maximum offset within which the entity will be considered near.
+ * @returns Whether the entity is within the threshold of its destination.
+ */
+export function isEntityNearDestination(entity: NPCType, threshold = 1) {
+	if (!entity.destination.state.value) {
+		throw new Error('Entity doesn\'t have a destination.')
+	}
+
+	const {
+		x: destinationX,
+		y: destinationY,
+	} = entity.destination.state.value
+	const {
+		x: entityX,
+		y: entityY,
+	} = entity.position.state
+
+	const dx = destinationX - entityX
+	const dy = destinationY - entityY
+
+	const distanceSquared = (dx ** 2) + (dy ** 2)
+
+	return distanceSquared <= threshold ** 2
+}

--- a/src/helpers/runSystems.ts
+++ b/src/helpers/runSystems.ts
@@ -8,6 +8,7 @@ import { Ticker } from 'pixi.js'
 // Local imports
 import { actorSystem } from '@/systems/actorSystem'
 import { attackSystem } from '@/systems/attackSystem'
+import { behaviorSystem } from '@/systems/behaviorSystem'
 import { cameraSystem } from '@/systems/cameraSystem'
 import { controlsSystem } from '@/systems/controlsSystem'
 import { entitySortSystem } from '@/systems/entitySortSystem'
@@ -15,7 +16,6 @@ import { movementSystem } from '@/systems/movementSystem'
 import { physicsSystem } from '@/systems/physicsSystem'
 import { spawnSystem } from '@/systems/spawnSystem'
 import { timeSystem } from '@/systems/timeSystem'
-
 
 
 
@@ -30,6 +30,7 @@ export function runSystems(ticker: Ticker) {
 	timeSystem()
 	spawnSystem()
 	controlsSystem()
+	behaviorSystem()
 	movementSystem()
 	attackSystem()
 	physicsSystem(ticker)

--- a/src/systems/behaviorSystem.ts
+++ b/src/systems/behaviorSystem.ts
@@ -1,0 +1,13 @@
+// Local imports
+import { query } from '@/helpers/ECS'
+
+
+
+
+
+/** Moves actor sprites based on their physics body's position. */
+export function behaviorSystem() {
+	for (const entity of query.npc) {
+		entity.behaviorTree.step()
+	}
+}

--- a/src/systems/movementSystem.ts
+++ b/src/systems/movementSystem.ts
@@ -18,7 +18,7 @@ export function movementSystem() {
 		for (const body of entity.bodies.bodies) {
 			Body.setVelocity(body, {
 				x: entity.velocity.state.x,
-				y: entity.velocity.state.y,
+				y: entity.velocity.state.y * 0.5,
 			})
 		}
 	}

--- a/src/typedefs/ActorType.ts
+++ b/src/typedefs/ActorType.ts
@@ -1,0 +1,15 @@
+// Module imports
+import { With } from 'miniplex'
+
+
+
+
+
+// Local imports
+import { Entity } from '@/typedefs/Entity'
+
+
+
+
+
+export type ActorType = With<Entity, 'actorType' | 'attack' | 'bodies' | 'position' | 'speed' | 'velocity' | 'zIndex'>

--- a/src/typedefs/DestinationState.ts
+++ b/src/typedefs/DestinationState.ts
@@ -1,0 +1,10 @@
+// Local imports
+import { Vector2 } from '@/typedefs/Vector2'
+
+
+
+
+
+export interface DestinationState {
+	value: Vector2 | null,
+}

--- a/src/typedefs/Entity.ts
+++ b/src/typedefs/Entity.ts
@@ -3,6 +3,7 @@ import {
 	type GridTile,
 	type ImageTile,
 } from 'pixi-tiled-loader'
+import { BehaviorTree } from 'behaviortree'
 import { Composite } from 'matter-js'
 import { type Store } from 'statery'
 
@@ -27,6 +28,7 @@ import { type ZIndexState } from '@/typedefs/ZIndexState'
 export type Entity = {
 	actorType?: keyof typeof ENTITY_CATALOGUE,
 	attack?: Store<AttackState>,
+	behaviorTree?: BehaviorTree,
 	bodies?: Composite,
 	health?: Store<HealthState>,
 	id?: UUID,

--- a/src/typedefs/Entity.ts
+++ b/src/typedefs/Entity.ts
@@ -13,6 +13,7 @@ import { type Store } from 'statery'
 
 // Local imports
 import { type AttackState } from '@/typedefs/AttackState'
+import { type DestinationState } from './DestinationState'
 import { ENTITY_CATALOGUE } from '@/constants/ENTITY_CATALOGUE'
 import { type HealthState } from '@/typedefs/HealthState'
 import { type PositionState } from '@/typedefs/PositionState'
@@ -30,6 +31,7 @@ export type Entity = {
 	attack?: Store<AttackState>,
 	behaviorTree?: BehaviorTree,
 	bodies?: Composite,
+	destination?: Store<DestinationState>,
 	health?: Store<HealthState>,
 	id?: UUID,
 	position?: Store<PositionState>,

--- a/src/typedefs/Entity.ts
+++ b/src/typedefs/Entity.ts
@@ -34,6 +34,10 @@ export type Entity = {
 	destination?: Store<DestinationState>,
 	health?: Store<HealthState>,
 	id?: UUID,
+	idle?: {
+		max: number,
+		min: number,
+	},
 	position?: Store<PositionState>,
 	spawn?: Store<SpawnState>,
 	speed?: number,

--- a/src/typedefs/EntityDefinition.ts
+++ b/src/typedefs/EntityDefinition.ts
@@ -1,4 +1,5 @@
 // Local imports
+import { Node as BehaviorNode } from 'behaviortree'
 import { COLLISION_CATEGORIES } from '@/constants/COLLISION_CATEGORIES'
 import { ENTITY_CATALOGUE } from '@/constants/ENTITY_CATALOGUE'
 import { type Vector2 } from '@/typedefs/Vector2'
@@ -9,6 +10,7 @@ import { type Vector2 } from '@/typedefs/Vector2'
 
 export interface EntityDefinition {
 	actorType: keyof typeof ENTITY_CATALOGUE,
+	behaviorTree?: BehaviorNode,
 	boundingBox: {
 		height: number,
 		width: number,

--- a/src/typedefs/EntityDefinition.ts
+++ b/src/typedefs/EntityDefinition.ts
@@ -30,6 +30,10 @@ export interface EntityDefinition {
 		width: number,
 	}],
 	health: number,
+	idle?: {
+		max: number,
+		min: number,
+	},
 	speed: number,
 	zOffset: number,
 }

--- a/src/typedefs/NPCType.ts
+++ b/src/typedefs/NPCType.ts
@@ -1,0 +1,15 @@
+// Module imports
+import { With } from 'miniplex'
+
+
+
+
+
+// Local imports
+import { ActorType } from '@/typedefs/ActorType'
+
+
+
+
+
+export type NPCType = With<ActorType, 'behaviorTree' | 'destination'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"behaviortree@npm:^3.0.0-beta.1":
+  version: 3.0.0-beta.1
+  resolution: "behaviortree@npm:3.0.0-beta.1"
+  dependencies:
+    core-js: "npm:^3.20.2"
+  checksum: 10c0/9862d1ae35db5844fc8a83abeabf246b03174184c87e0e2e9a877b5e8a618947e8290439dd42322b121cade62b81302b2efa4e244c3a780781b85f701d25e50e
+  languageName: node
+  linkType: hard
+
 "binary-extensions@npm:^2.0.0":
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
@@ -2722,6 +2731,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.20.2":
+  version: 3.39.0
+  resolution: "core-js@npm:3.39.0"
+  checksum: 10c0/f7602069b6afb2e3298eec612a5c1e0c3e6a458930fbfc7a4c5f9ac03426507f49ce395eecdd2d9bae9024f820e44582b67ffe16f2272395af26964f174eeb6b
+  languageName: node
+  linkType: hard
+
 "cpu-features@npm:^0.0.10":
   version: 0.0.10
   resolution: "cpu-features@npm:0.0.10"
@@ -2953,6 +2969,7 @@ __metadata:
     "@types/react-dom": "npm:^18"
     "@typescript-eslint/eslint-plugin": "npm:7.8.0"
     "@typescript-eslint/parser": "npm:7.8.0"
+    behaviortree: "npm:^3.0.0-beta.1"
     eslint: "npm:^8"
     eslint-config-next: "npm:^15.1.0"
     eslint-plugin-editorconfig: "npm:^4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,9 +5,9 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@assetpack/core@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "@assetpack/core@npm:1.2.2"
+"@assetpack/core@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "@assetpack/core@npm:1.2.3"
   dependencies:
     "@ffmpeg-installer/ffmpeg": "npm:^1.1.0"
     "@napi-rs/woff-build": "npm:^0.2.0"
@@ -45,7 +45,7 @@ __metadata:
     upath: "npm:^2.0.1"
   bin:
     assetpack: bin/index.js
-  checksum: 10c0/2143a8dfc7336552d108c77220e4ecb8f28f5fb7649bc7344a8f3d45f02879e90000378a197b8d820be62329618aecaf45409e4c343b349c87ea20677a6aa965
+  checksum: 10c0/db87bd4ee1fb708812d75008bf319a1302f9c247dfcad58de844384a63d2987f51bc2edde893a9a80e1e81e3d33f2f4b01533cd0f2297893b0bff15b6d65e017
   languageName: node
   linkType: hard
 
@@ -2956,7 +2956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "discord-activity@workspace:."
   dependencies:
-    "@assetpack/core": "npm:^1.2.2"
+    "@assetpack/core": "npm:^1.2.3"
     "@pixi/devtools": "npm:^2.0.1"
     "@pixi/react": "npm:8.0.0-beta.14"
     "@trezy-studios/eslint-config": "npm:^1.0.0"


### PR DESCRIPTION
* Adds the `behaviortree.js` library
* Adds several reusable behaviors for use within behavior trees
* Adds wandering behavior to the merchant
* Adds a new query for NPCs (selects based on the existence of the `behaviorTree` and `destination` components)
* Cleans up types for actor creation
  * We were previously getting lucky with type inference when creating stores, so they're now explicitly typed and abstracted into helper functions